### PR TITLE
Fixed Cannot bind parameter 'Password'. 

### DIFF
--- a/Azure/SPNCreation.ps1
+++ b/Azure/SPNCreation.ps1
@@ -22,6 +22,7 @@ $displayName = [String]::Format("VSO.{0}.{1}", $userName, $newguid)
 $homePage = "http://" + $displayName
 $identifierUri = $homePage
 
+$passwordAsSecureString = $password | ConvertTo-SecureString -asPlainText -Force
 
 #Initialize subscription
 $isAzureModulePresent = Get-Module -Name AzureRM* -ListAvailable
@@ -42,7 +43,7 @@ $id = $azureSubscription.SubscriptionId
 
 #Create a new AD Application
 Write-Output "Creating a new Application in AAD (App URI - $identifierUri)" -Verbose
-$azureAdApplication = New-AzureRmADApplication -DisplayName $displayName -HomePage $homePage -IdentifierUris $identifierUri -Password $password -Verbose
+$azureAdApplication = New-AzureRmADApplication -DisplayName $displayName -HomePage $homePage -IdentifierUris $identifierUri -Password $passwordAsSecureString -Verbose
 $appId = $azureAdApplication.ApplicationId
 Write-Output "Azure AAD Application creation completed successfully (Application Id: $appId)" -Verbose
 


### PR DESCRIPTION
I was getting a "Cannot bind parameter 'Password'. Cannot convert the "xxxxx" value of type "System.String" to type 
 System.Security.SecureString".

Converting the password to a secure-string fixed it for me