### PR TITLE
Fixed SecureString issue

### DIFF
--- a/Azure/SPNCreation.ps1
+++ b/Azure/SPNCreation.ps1
@@ -42,7 +42,9 @@ $id = $azureSubscription.SubscriptionId
 
 #Create a new AD Application
 Write-Output "Creating a new Application in AAD (App URI - $identifierUri)" -Verbose
-$azureAdApplication = New-AzureRmADApplication -DisplayName $displayName -HomePage $homePage -IdentifierUris $identifierUri -Password $password -Verbose
+
+$passwordAsSecureString = ConvertTo-SecureString $password -AsPlainText -Force
+$azureAdApplication = New-AzureRmADApplication -DisplayName $displayName -HomePage $homePage -IdentifierUris $identifierUri -Password $passwordAsSecureString -Verbose
 $appId = $azureAdApplication.ApplicationId
 Write-Output "Azure AAD Application creation completed successfully (Application Id: $appId)" -Verbose
 


### PR DESCRIPTION
I was getting a "Cannot bind parameter 'Password'. Cannot convert the "xxxxx" value of type "System.String" to type System.Security.SecureString".

This issue is related to "New-AzureRmADApplication" requring -password parameter needing to be a Secure-String. See "https://docs.microsoft.com/en-us/powershell/module/azurerm.resources/new-azurermadapplication"