### PR TITLE
Changed $Password so it is a secure string...

### DIFF
--- a/Azure/SPNCreation.ps1
+++ b/Azure/SPNCreation.ps1
@@ -3,8 +3,8 @@ param
     [Parameter(Mandatory=$true, HelpMessage="Enter Azure Subscription name. You need to be Subscription Admin to execute the script")]
     [string] $subscriptionName,
 
-    [Parameter(Mandatory=$true, HelpMessage="Provide a password for SPN application that you would create")]
-    [string] $password,
+    [Parameter(Mandatory=$true, HelpMessage="Provide a password for SPN application that you would create; this becomes the service principal's security key")]
+    [securestring] $password,
 
     [Parameter(Mandatory=$false, HelpMessage="Provide a SPN role assignment")]
     [string] $spnRole = "owner",


### PR DESCRIPTION
When I attempted to execute this powershell script, I received type casting error because PowerShell couldn't convert the `string` to a `securestring`.  Changing the way the parameter is originally casted solves this problem and gives the user a way to enter the string without it displaying in the clear.