### PR TITLE
Removing the file winrmconf.cmd as it is no longer in use

### DIFF
--- a/WinRM/WinRM-Http-Https-With-Makecert/winrmconf.cmd
+++ b/WinRM/WinRM-Http-Https-With-Makecert/winrmconf.cmd
@@ -1,1 +1,0 @@
-winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="%1";CertificateThumbprint="%2"}


### PR DESCRIPTION
Removing the file winrmconf.cmd as it is no longer in use